### PR TITLE
Fixed missing text due to i18next

### DIFF
--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import 'utils/intl';
 import AdminLayout from '@components/layouts/adminLayout';
 import { ReactNode } from 'react';
 

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import 'utils/intl';
 import ContentPlaceholder from '@components/atom/ContentPlaceholder/ContentPlaceholder';
 import React from 'react';
 import { useDocumentTitle } from '@hooks/useDocumentTitle/useDocumentTitle';

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import 'utils/intl';
 import Login from '@components/auth/login';
 import React from 'react';
 import { useDocumentTitle } from '@hooks/useDocumentTitle/useDocumentTitle';

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import 'utils/intl';
 import Signup from '@components/auth/signup';
 import React from 'react';
 import { useDocumentTitle } from '@hooks/useDocumentTitle/useDocumentTitle';

--- a/src/providers/AppProviders.tsx
+++ b/src/providers/AppProviders.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import 'utils/intl';
 import { SessionProvider } from 'next-auth/react';
 import { Flowbite } from 'flowbite-react';
 import { ReactNode } from 'react';


### PR DESCRIPTION
Part of issue #193 

What was happening was that i18next was being used on only the client-rendered pages (so, the admin and login/signup pages). But for i18next to work in our current setup, it needs to have its initializer run on initial page load, which is located in the `utils/intl.tsx` file. It can only work in components with "use client", hence the `import 'utils/intl'` statement was only in the layout files for those client-rendered pages

The problem was that it was only working if you opened that page directly, and wouldn't work if you started on a server-rendered page (like the homepage) then navigated to a client-rendered page. So I've instead just moved it to the `AppProviders` file, which will make it load on all pages