### PR TITLE
Add engines field to specify required Node.js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "lint": "npx oxlint --fix",
     "pm2": "pm2 start npm --name \"sparked-next\" -- start"
   },
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@auth/mongodb-adapter": "^3.0.0",
     "@aws-sdk/client-s3": "^3.598.0",


### PR DESCRIPTION
This fixes: error on build using nixpark 
Platform running:
- Dockploy on Ubuntu
This might also fix build error on render as the build error is not specific. 

Deployed on http://sparked-fron-obk0y3-1ca9b9-31-97-116-22.traefik.me/