### PR TITLE
Add Logout on Library navigation 

### DIFF
--- a/src/components/library/libraryLayout/LibraryNavbar.tsx
+++ b/src/components/library/libraryLayout/LibraryNavbar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { DarkThemeToggle, Navbar, TextInput } from 'flowbite-react';
+import { Avatar, Button, DarkThemeToggle, Dropdown, Navbar, TextInput } from 'flowbite-react';
 import Link from 'next/link';
 import { useState } from 'react';
 import { HiSearch, HiX } from 'react-icons/hi';
@@ -52,6 +52,26 @@ export function LibraryNavbar({
             icon={HiSearch}
           />
         </form>
+
+        <Dropdown
+          label="User"
+          renderTrigger={() => (
+            <Avatar
+              id="dropdownHoverButton"
+              data-dropdown-toggle="dropdownHover"
+              data-dropdown-trigger="hover"
+              // src="/avatar.png"
+              alt="User Avatar"
+              size="xs"
+              rounded
+            />
+          )}
+        >
+          <Dropdown.Item>
+            <Link href="/library/logout">Logout</Link>
+          </Dropdown.Item>
+        </Dropdown>
+
         <button
           onClick={() => setSearching((value) => !value)}
           className="rounded-lg md:hidden p-2.5 text-sm text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-4 focus:ring-gray-200 dark:text-gray-400 dark:hover:bg-gray-700 dark:focus:ring-gray-700"

--- a/src/components/library/libraryLayout/LibraryNavbar.tsx
+++ b/src/components/library/libraryLayout/LibraryNavbar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Avatar, Button, DarkThemeToggle, Dropdown, Navbar, TextInput } from 'flowbite-react';
+import { Avatar, DarkThemeToggle, Dropdown, Navbar, TextInput } from 'flowbite-react';
 import Link from 'next/link';
 import { useState } from 'react';
 import { HiSearch, HiX } from 'react-icons/hi';
@@ -8,6 +8,8 @@ import { MdMenu } from 'react-icons/md';
 import AppLogo from '@components/logo';
 import { extractValuesFromFormEvent } from 'utils/helpers/extractValuesFromFormEvent';
 import { useRouter } from 'next-nprogress-bar';
+import useAuth from '@hooks/useAuth';
+import { routes } from 'routes';
 
 export function LibraryNavbar({
   toggleSidebar,
@@ -18,10 +20,10 @@ export function LibraryNavbar({
 }) {
   let [searching, setSearching] = useState(false);
   let router = useRouter();
-
+  const { handleLogout, loading } = useAuth();
   return (
-    <Navbar fluid rounded className="sticky top-0 z-[60]">
-      <div className={`pl-2 flex flex-row gap-4 ${searching ? 'hidden md:flex' : ''}`}>
+    <Navbar fluid rounded className="sticky top-0 z-[60]  flex-nowrap">
+      <div className={`pl-2 flex flex-row sm:gap-2 md:gap-4 flex-nowrap ${searching ? 'hidden md:flex' : ''}`}>
         <button type="button" className="text-gray-500 -ml-3 mr-1 p-2 md:ml-0 md:mr-0 " onClick={toggleSidebar}>
           {sidebarIsCollapsed ? (
             <MdMenu aria-label="Open sidebar" className="h-6 w-6 cursor-pointer text-gray-500 dark:text-gray-400" />
@@ -29,7 +31,7 @@ export function LibraryNavbar({
             <HiX aria-label="Close sidebar" className="h-6 w-6 cursor-pointer text-gray-500 dark:text-gray-400" />
           )}
         </button>
-        <Navbar.Brand as={Link} href="/library">
+        <Navbar.Brand className="sm: w-1/3 md:w-fit " as={Link} href="/library">
           <AppLogo />
         </Navbar.Brand>
       </div>
@@ -68,7 +70,9 @@ export function LibraryNavbar({
           )}
         >
           <Dropdown.Item>
-            <Link href="/library/logout">Logout</Link>
+            <Link href={routes.home} onClick={handleLogout} aria-disabled={loading}>
+              Logout
+            </Link>
           </Dropdown.Item>
         </Dropdown>
 


### PR DESCRIPTION
This pull request updates the `LibraryNavbar` component to improve user experience and add authentication-related functionality. The main changes include integrating a user dropdown menu with logout support, updating layout and styling for better responsiveness, and refactoring imports.

**Authentication and User Menu:**
* Added a user avatar dropdown to the navbar, which includes a logout option that uses the `useAuth` hook for authentication management.
* Integrated the `useAuth` hook to manage logout state and loading indicator.

**Layout and Responsiveness:**
* Updated navbar layout classes to use `flex-nowrap` and adjusted gap classes for better responsiveness across screen sizes.
* Modified the `Navbar.Brand` element to use responsive width classes for improved layout on small and medium screens.

**Code Refactoring:**
* Refactored imports to include `Avatar`, `Dropdown`, and authentication hooks, removing unused code and improving organization.